### PR TITLE
Make server reachable from VPN

### DIFF
--- a/srv/salt/omv/deploy/wireguard/default.sls
+++ b/srv/salt/omv/deploy/wireguard/default.sls
@@ -46,7 +46,7 @@ configure_wireguard_wgnet{{ tnum }}_{{ tname }}:
     - name: "{{ scfg }}"
     - text: |
         [Interface]
-        Address = 10.192.{{ tnum }}.255/24
+        Address = 10.192.{{ tnum }}.254/24
         SaveConfig = true
         ListenPort = {{ tl.port }}
         PrivateKey = {{ tl.privatekeyserver }}
@@ -90,7 +90,7 @@ configure_wireguard_client_wgnet{{ cnum }}:
     - name: "{{ ccfg }}"
     - text: |
         [Interface]
-        Address = 10.192.{{ tnum }}.{{ cnum }}/32
+        Address = 10.192.{{ tnum }}.{{ cnum }}/24
         PrivateKey = {{ ct.privatekeyclient }}
 
 configure_wireguard_client_wgnet{{ cnum }}_{{ cname }}_peer:

--- a/usr/share/openmediavault/datamodels/conf.service.wireguard.client.json
+++ b/usr/share/openmediavault/datamodels/conf.service.wireguard.client.json
@@ -19,7 +19,7 @@
     "clientnum": {
       "type": "integer",
       "minimum": 1,
-      "maximum": 254
+      "maximum": 253
     },
     "tunnelnum": {
       "type": "integer",

--- a/usr/share/openmediavault/datamodels/conf.service.wireguard.json
+++ b/usr/share/openmediavault/datamodels/conf.service.wireguard.json
@@ -77,7 +77,7 @@
               "clientnum": {
                 "type": "integer",
                 "minimum": 1,
-                "maximum": 254
+                "maximum": 253
               },
               "tunnelnum": {
                 "type": "integer",

--- a/usr/share/openmediavault/datamodels/rpc.wireguard.json
+++ b/usr/share/openmediavault/datamodels/rpc.wireguard.json
@@ -11,7 +11,7 @@
         "clientnum": {
           "type": "integer",
           "minimum": 1,
-          "maximum": 254
+          "maximum": 253
         },
         "tunnelnum": {
           "type": "integer",

--- a/usr/share/openmediavault/workbench/component.d/omv-services-wireguard-clients-form-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-services-wireguard-clients-form-page.yaml
@@ -28,7 +28,7 @@ data:
         value: 1
         validators:
           min: 1
-          max: 254
+          max: 253
           required: true
         modifiers:
           - type: disabled


### PR DESCRIPTION
Hello !

In a quite recent commit, the server interface is given the IP 10.192.x.255 in order to make the very first IPs of the subnet available to the clients. This is understandable, but 10.192.x.255 is actually the broadcast IP of the subnet, making the server unreachable from the tunnel. (pinging other clients and proxying other packets work fine, it's just that we can't ping the server with the IP 10.192.x.255)

I though this was a mistake, and the idea behind was to give the server the last available IP on the subnet, which is actually 10.192.x.254.

Also the client interface is given an IP as /32 in its config, which means the client think he's the only one in his subnet. Actually, the subnets managed by this plugin are all /24.