### PR TITLE
restrict AllowedIPs at client side

### DIFF
--- a/srv/salt/omv/deploy/wireguard/default.sls
+++ b/srv/salt/omv/deploy/wireguard/default.sls
@@ -102,7 +102,7 @@ configure_wireguard_client_wgnet{{ cnum }}_{{ cname }}_peer:
         PublicKey = {{ tl.publickeyserver }}
         PresharedKey = {{ ct.presharedkeyclient }}
         Endpoint = {{ tl.endpoint }}:{{ tl.port }}
-        AllowedIPs = 0.0.0.0/0
+        AllowedIPs = 10.192.{{ tnum }}.0/24
 
 create_wireguard_qr_code_wgnet{{ cnum }}:
   cmd.run:


### PR DESCRIPTION
Restrict the AllowedIPs at client side to the tunnel subnet so that only the traffic targeting the tunnel subnet will be routed to the server. This matches the common usage of VPN in NAS scenario that the client may setup a channel to server to access its services while let other network traffic go through the default gateway on the client.