### PR TITLE
Add possibility to use local ip and better view for clients parameter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+openmediavault-wireguard (6.3.5) stable; urgency=low
+
+  * Add possibility to use local ip without the need to use custom config
+  * Add local ip colonn to client tab
+  * Add restrict colonn to client tab
+  * Add persistent keepalive colonn to client tab
+
+ -- Elenedeath <Elenedeath@github.com>  Tue, 21 Aug 2023 15:15:05 -0500
+
 openmediavault-wireguard (6.3.4) stable; urgency=low
 
   * Add dummy config for when database is empty

--- a/srv/salt/omv/deploy/wireguard/default.sls
+++ b/srv/salt/omv/deploy/wireguard/default.sls
@@ -20,6 +20,7 @@
 {% for tl in config.tunnels.tunnel %}
 {% set tnum = tl.tunnelnum %}
 {% set tname = tl.tunnelname %}
+{% set tip = tl.localserver %}
 {% set scfg = '/etc/wireguard/wgnet' ~ tnum ~ '.conf' %}
 {% set iptab = tl.iptables %}
 
@@ -104,7 +105,11 @@ configure_wireguard_client_wgnet{{ cnum }}_{{ cname }}_peer:
         PublicKey = {{ tl.publickeyserver }}
         PresharedKey = {{ ct.presharedkeyclient }}
         Endpoint = {{ tl.endpoint }}:{{ tl.port }}
-        AllowedIPs = {{ "10.192." ~ tnum ~ ".0/24" if ct.restrict | to_bool else "0.0.0.0/0" }}
+    {% if ct.localip %}
+        AllowedIPs = {{"10.192." ~ tnum ~ ".0/24, " ~ tip ~ ""if ct.restrict | to_bool else "0.0.0.0/0"}}
+    {% else %}
+        AllowedIPs = {{"10.192." ~ tnum ~ ".0/24"if ct.restrict | to_bool else "0.0.0.0/0"}}
+    {% endif %}
         {% if ct.persistent > 0 %}PersistentKeepalive = {{ ct.persistent }}{% endif %}
 
 

--- a/usr/share/openmediavault/datamodels/conf.service.wireguard.client.json
+++ b/usr/share/openmediavault/datamodels/conf.service.wireguard.client.json
@@ -32,6 +32,9 @@
     "restrict": {
       "type": "boolean"
     },
+    "localip": {
+      "type": "boolean"
+    },
     "persistent": {
       "type": "integer",
       "minimum": 0,

--- a/usr/share/openmediavault/datamodels/conf.service.wireguard.json
+++ b/usr/share/openmediavault/datamodels/conf.service.wireguard.json
@@ -37,6 +37,9 @@
               "endpoint": {
                 "type": "string"
               },
+              "localserver": {
+                "type": "string"
+              },
               "port": {
                 "type": "integer",
                 "minimum": 1,
@@ -98,6 +101,10 @@
                 "type": "string"
               },
               "restrict": {
+                "type": "boolean",
+                "default": false
+              },
+              "localip": {
                 "type": "boolean",
                 "default": false
               },

--- a/usr/share/openmediavault/datamodels/conf.service.wireguard.tunnel.json
+++ b/usr/share/openmediavault/datamodels/conf.service.wireguard.tunnel.json
@@ -30,6 +30,9 @@
     "endpoint": {
       "type": "string"
     },
+    "localserver": {
+      "type": "string"
+    },
     "port": {
       "type": "integer",
       "minimum": 1,

--- a/usr/share/openmediavault/datamodels/rpc.wireguard.json
+++ b/usr/share/openmediavault/datamodels/rpc.wireguard.json
@@ -24,6 +24,9 @@
         "restrict": {
           "type": "boolean"
         },
+        "localip": {
+          "type": "boolean"
+        },
         "persistent": {
           "type": "integer",
           "minimum": 0,

--- a/usr/share/openmediavault/locale/ach/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/ach/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/ach/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/ach/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/ady/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/ady/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/ady/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/ady/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/ar_SA/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/ar_SA/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/ar_SA/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/ar_SA/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/bg/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/bg/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/bg/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/bg/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/ca_ES/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/ca_ES/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/ca_ES/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/ca_ES/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/cs_CZ/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/cs_CZ/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/cs_CZ/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/cs_CZ/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/da_DA/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/da_DA/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/da_DA/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/da_DA/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/de_DE/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/de_DE/openmediavault-wireguard.po
@@ -92,6 +92,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr "Endpunkt"
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/de_DE/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/de_DE/openmediavault-wireguard.po
@@ -125,6 +125,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/en_GB/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/en_GB/openmediavault-wireguard.po
@@ -125,6 +125,12 @@ msgstr "Restrict"
 msgid "Restrict routing to VPN subnet only"
 msgstr "Restrict routing to VPN subnet only"
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr "Set to 0 to disable"
 

--- a/usr/share/openmediavault/locale/en_GB/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/en_GB/openmediavault-wireguard.po
@@ -92,6 +92,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr "Endpoint"
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/es_CO/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/es_CO/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/es_CO/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/es_CO/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/es_ES/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/es_ES/openmediavault-wireguard.po
@@ -125,6 +125,12 @@ msgstr "Restringir"
 msgid "Restrict routing to VPN subnet only"
 msgstr "Restringir el enrutado a la VPN exclusivamente."
 
+msgid "localip"
+msgstr "localip"
+
+msgid "Restrict routing to local subnet only"
+msgstr "Restringir el enrutado a la local exclusivamente."
+
 msgid "Set to 0 to disable"
 msgstr "0 para deshabilitar"
 

--- a/usr/share/openmediavault/locale/es_ES/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/es_ES/openmediavault-wireguard.po
@@ -92,6 +92,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr "Endpoint"
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/fi/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/fi/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/fi/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/fi/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/fr_FR/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/fr_FR/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/fr_FR/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/fr_FR/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/gl/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/gl/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/gl/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/gl/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/hu/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/hu/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/hu/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/hu/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/hu_HU/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/hu_HU/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/hu_HU/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/hu_HU/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/it_IT/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/it_IT/openmediavault-wireguard.po
@@ -125,6 +125,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/it_IT/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/it_IT/openmediavault-wireguard.po
@@ -92,6 +92,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr "Endpoint"
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/ja_JP/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/ja_JP/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/ja_JP/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/ja_JP/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/jv/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/jv/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/jv/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/jv/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/ko_KR/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/ko_KR/openmediavault-wireguard.po
@@ -92,6 +92,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/ko_KR/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/ko_KR/openmediavault-wireguard.po
@@ -125,6 +125,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/nl_BE/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/nl_BE/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/nl_BE/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/nl_BE/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/nl_NL/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/nl_NL/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/nl_NL/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/nl_NL/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/no_NO/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/no_NO/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/no_NO/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/no_NO/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/oc/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/oc/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/oc/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/oc/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/openmediavault-wireguard.pot
+++ b/usr/share/openmediavault/locale/openmediavault-wireguard.pot
@@ -119,6 +119,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/openmediavault-wireguard.pot
+++ b/usr/share/openmediavault/locale/openmediavault-wireguard.pot
@@ -86,6 +86,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/pl/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/pl/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/pl/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/pl/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/pl_PL/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/pl_PL/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/pl_PL/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/pl_PL/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/pt/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/pt/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/pt/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/pt/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/pt_BR/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/pt_BR/openmediavault-wireguard.po
@@ -125,6 +125,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/pt_BR/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/pt_BR/openmediavault-wireguard.po
@@ -92,6 +92,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr "Endpoint"
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/ru_RU/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/ru_RU/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/ru_RU/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/ru_RU/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/sv_SV/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/sv_SV/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/sv_SV/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/sv_SV/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/tr/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/tr/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/tr/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/tr/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/uk_UK/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/uk_UK/openmediavault-wireguard.po
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr ""
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/uk_UK/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/uk_UK/openmediavault-wireguard.po
@@ -121,6 +121,12 @@ msgstr ""
 msgid "Restrict routing to VPN subnet only"
 msgstr ""
 
+msgid "localip"
+msgstr ""
+
+msgid "Restrict routing to local subnet only"
+msgstr ""
+
 msgid "Set to 0 to disable"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/zh_CN/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/zh_CN/openmediavault-wireguard.po
@@ -125,6 +125,12 @@ msgstr "限制"
 msgid "Restrict routing to VPN subnet only"
 msgstr "仅限 VPN 子网路由"
 
+msgid "localip"
+msgstr "当地的"
+
+msgid "Restrict routing to local subnet only"
+msgstr "仅限本地子网路由"
+
 msgid "Set to 0 to disable"
 msgstr "设置 0 以停用"
 

--- a/usr/share/openmediavault/locale/zh_CN/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/zh_CN/openmediavault-wireguard.po
@@ -92,6 +92,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr "对端"
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/zh_TW/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/zh_TW/openmediavault-wireguard.po
@@ -92,6 +92,9 @@ msgstr ""
 msgid "Endpoint"
 msgstr "端點"
 
+msgid "Local Server"
+msgstr ""
+
 msgid "MTU"
 msgstr ""
 

--- a/usr/share/openmediavault/locale/zh_TW/openmediavault-wireguard.po
+++ b/usr/share/openmediavault/locale/zh_TW/openmediavault-wireguard.po
@@ -125,6 +125,12 @@ msgstr "限制"
 msgid "Restrict routing to VPN subnet only"
 msgstr "限制只能選路到 VPN 子網路"
 
+msgid "localip"
+msgstr "当地的"
+
+msgid "Restrict routing to local subnet only"
+msgstr "限制只能選路到 local 子網路"
+
 msgid "Set to 0 to disable"
 msgstr "設定成 0 來停用"
 

--- a/usr/share/openmediavault/workbench/component.d/omv-services-wireguard-clients-datatable-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-services-wireguard-clients-datatable-page.yaml
@@ -33,6 +33,18 @@ data:
         prop: tunnelnum
         flexGrow: 1
         sortable: true
+      - name: _("Local IP")
+        prop: localip
+        flexGrow: 1
+        sortable: true
+      - name: _("Restrict")
+        prop: restrict
+        flexGrow: 1
+        sortable: true
+      - name: _("Persistent keepalive")
+        prop: persistent
+        flexGrow: 1
+        sortable: true
       - name: _("QR Code")
         prop: qrcode
         flexGrow: 3

--- a/usr/share/openmediavault/workbench/component.d/omv-services-wireguard-clients-form-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-services-wireguard-clients-form-page.yaml
@@ -61,6 +61,11 @@ data:
         label: _("Restrict")
         value: false
         hint: _("Restrict routing to VPN subnet only")
+      - type: checkbox
+        name: localip
+        label: _("Local IP")
+        value: false
+        hint: _("Restrict routing to local subnet only")
       - type: numberInput
         name: persistent
         label: _("Persistent keepalive")

--- a/usr/share/openmediavault/workbench/component.d/omv-services-wireguard-tunnels-datatable-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-services-wireguard-tunnels-datatable-page.yaml
@@ -37,6 +37,10 @@ data:
         prop: endpoint
         flexGrow: 1
         sortable: true
+      - name: _("Local Server")
+        prop: localserver
+        flexGrow: 1
+        sortable: true
       - name: _("Port")
         prop: port
         flexGrow: 1

--- a/usr/share/openmediavault/workbench/component.d/omv-services-wireguard-tunnels-form-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-services-wireguard-tunnels-form-page.yaml
@@ -54,6 +54,10 @@ data:
         name: endpoint
         label: _("Endpoint")
         value: ""
+      - type: textInput
+        name: localserver
+        label: _("Local Server")
+        value: ""
       - type: numberInput
         name: port
         label: _("Port")


### PR DESCRIPTION
  Hello,
i add the possibility to set a custom ip in the tunnel edition pages like this you can use it in your clients settings with simply check the local ip checkbox

when you check the local ip checkbox and the restrict you got
`AllowedIPs = 10.192.1.0/24, 192.168.1.0/24`

without local ip and restrict checked you got
`AllowedIPs = 10.192.1.0/24`

with nothing checked (no check on restrict and local ip)
`AllowedIPs = 0.0.0.0/0`